### PR TITLE
Bump Rust edition to 2024 and update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,9 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --verbose
       - name: Run unit tests

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -13,11 +13,9 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Install security audit
         run: cargo install cargo-audit
       - name: Run security audit
@@ -26,11 +24,10 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
       - name: Check code formatting
         run: cargo fmt --check --all
@@ -38,11 +35,10 @@ jobs:
     name: Clippy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
       - name: Clippy
         run: cargo clippy --all-targets
@@ -51,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Linelint
         uses: fernandrone/linelint@master
         id: linelint
@@ -59,12 +55,9 @@ jobs:
     name: Look for unused dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install unused dependency checker
         run: cargo install cargo-udeps --locked
       - name: Run unused dependency checker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,15 @@
 name = "fng_api_wrapper"
 description = "Crypto Fear and Greed API wrapper"
 version = "1.0.2"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 repository = "https://github.com/gcomte/fng-api-wrapper"
 
 [dependencies]
-chrono = { version = "0.4.23", default-features = false }
-serde = { version = "1.0.152", features = ["derive"] }
-serde-aux = "4.1.2"
-serde_json = "1.0.91"
-thiserror = "2.0.11"
-ureq = "3.0.2"
+chrono = { version = "0.4.44", default-features = false }
+serde = { version = "1.0.228", features = ["derive"] }
+serde-aux = "4.7.0"
+serde_json = "1.0.149"
+thiserror = "2.0.18"
+ureq = "3.3.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,8 +8,12 @@ pub enum FngApiError {
     ParseResultError(#[from] ureq::Error),
     #[error("Parsing the JSON response failed.")]
     ParseJsonError(#[from] serde_json::Error),
-    #[error("Received records for fewer days than requested. This is likely because you a wider time frame than the API provides. Consider calling fetch_daily_fng_max_records instead of fetch_daily_fng(amt_days_in_past).")]
+    #[error(
+        "Received records for fewer days than requested. This is likely because you a wider time frame than the API provides. Consider calling fetch_daily_fng_max_records instead of fetch_daily_fng(amt_days_in_past)."
+    )]
     ReceivedLessRecords,
-    #[error("Received records for more days than requested. This is unexpected behavior. Please report this bug.")]
+    #[error(
+        "Received records for more days than requested. This is unexpected behavior. Please report this bug."
+    )]
     ReceivedMoreRecords,
 }


### PR DESCRIPTION
## Summary
- Bump Rust edition from **2021 → 2024** and set `rust-version = "1.85"` (MSRV).
- Update direct dependencies in `Cargo.toml` to latest: `chrono` 0.4.44, `serde` 1.0.228, `serde-aux` 4.7.0, `serde_json` 1.0.149, `thiserror` 2.0.18, `ureq` 3.3.0. `cargo update` pulls transitive deps to latest compatible versions.
- Modernize GitHub Actions workflows: replace the archived `actions-rs/toolchain@v1.0.6` with `dtolnay/rust-toolchain@stable`, and bump `actions/checkout` to `v4`.
- Reformat `src/errors.rs` to satisfy `rustfmt`'s edition 2024 style.

## Test plan
- [x] `cargo build --verbose`
- [x] `cargo test --lib --verbose`
- [x] `cargo test --test '*' --verbose`
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check --all`
- [ ] CI green on the PR